### PR TITLE
calculate fan-in correctly

### DIFF
--- a/ddpg-bipedal/model.py
+++ b/ddpg-bipedal/model.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 def hidden_init(layer):
-    fan_in = layer.weight.data.size()[0]
+    fan_in = layer.weight.data.size()[1]
     lim = 1. / np.sqrt(fan_in)
     return (-lim, lim)
 

--- a/ddpg-pendulum/model.py
+++ b/ddpg-pendulum/model.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 def hidden_init(layer):
-    fan_in = layer.weight.data.size()[0]
+    fan_in = layer.weight.data.size()[1]
     lim = 1. / np.sqrt(fan_in)
     return (-lim, lim)
 


### PR DESCRIPTION
Fan-in is defined to be the maximum number of inputs to a layer.
The weight matrix is transposed.
This means that the number of inputs are equal to the second component in the shape not the first one (0-indexing). 