### PR TITLE
Update Monte_Carlo_Solution.ipynb

### DIFF
--- a/monte-carlo/Monte_Carlo_Solution.ipynb
+++ b/monte-carlo/Monte_Carlo_Solution.ipynb
@@ -233,11 +233,11 @@
     "        # obtain the states, actions, and rewards\n",
     "        states, actions, rewards = zip(*episode)\n",
     "        # prepare for discounting\n",
-    "        discounts = np.array([gamma**i for i in range(len(rewards)+1)])\n",
+    "        discounts = np.array([gamma**i for i in range(len(rewards))])\n",
     "        # update the sum of the returns, number of visits, and action-value \n",
     "        # function estimates for each state-action pair in the episode\n",
     "        for i, state in enumerate(states):\n",
-    "            returns_sum[state][actions[i]] += sum(rewards[i:]*discounts[:-(1+i)])\n",
+    "            returns_sum[state][actions[i]] += sum(rewards[i+1:]*discounts[:-(1+i)])\n",
     "            N[state][actions[i]] += 1.0\n",
     "            Q[state][actions[i]] = returns_sum[state][actions[i]] / N[state][actions[i]]\n",
     "    return Q"


### PR DESCRIPTION
returns_sum += returns_sum + expectation. Since it is expectation (sum of future rewards), the rewards should start from the index 'i+1' rather than 'i'.  Also, if it starts at 'i+1', discounts can be generated up to 'i' itself instead of 'i+1'.