### PR TITLE
Remove the version requirement of torch for Windows 10

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,7 +8,7 @@ docopt
 pyyaml
 protobuf==3.5.2
 grpcio==1.11.0
-torch==0.4.0
+torch
 pandas
 scipy
 ipykernel


### PR DESCRIPTION
In windows 10, torch==0.4.0 is not available. In my case, without the version requirement, there is no problem doing three projects.